### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "reason-react": "0.2.1"
+    "reason-react": "0.2.4"
   },
   "devDependencies": {
     "bs-platform": "^2.0.0",


### PR DESCRIPTION
While going through the tutorial, the compiler couldn't find `ReasonReact.reducerComponent`. After doing some research, I realized that it's because you updated the blog to use the most recent stuff (like SUPER recent) but never updated the version of `reason-react` in this repo. So it wasn't bring in the new stuff. Figured I'd update it for you. :)